### PR TITLE
[v1] Use child injectors in each service call.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 repos:
 
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 20.8b1
     hooks:
     - id: black
       language_version: python3.6

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ nameko-injector
 ===============
 
 `injector <https://pypi.org/project/injector/>`_ based dependency injection
-mechanism for the nameko services. Project is similar to `flask-injector <https://pypi.org/project/Flask-Injector/>`_.
+mechanism for nameko services. Project is similar to `flask-injector <https://pypi.org/project/Flask-Injector/>`_.
 
 Problem
 -------
@@ -13,6 +13,8 @@ It works in many cases but there are limitations:
 1. All the dependencies are injected regardless of whether they are used in the entry-point. For instance, all the dependencies will be injected for ``/health`` HTTP entry point.
 2. Dependencies cannot depend on each other.
 3. The scope is an implementation detail. Frequency of the dependency creation depends on the ``DependencyProvider`` implementation.
+4. Subjectively, implementing a new `DependencyProvider` is not the easiest
+   the task for the developers.
 
 Solution
 --------
@@ -21,7 +23,6 @@ The library provides an alternative dependency injection mechanism to the one
 that is built-in in nameko. Several types of `request` scope can
 be used out of the box without special injector module declarations.
 
-- ``nameko_injector.core.ServiceConfig``
 - ``from nameko.containers.ServiceContainer``
 - ``from nameko.containers.WorkerContext``
 
@@ -49,6 +50,51 @@ An example:
       def view_config(self, request, config: ServiceConfig):
         return json.dumps(config)
 
+Testing with library
+--------------------
+The library provides a module for pytest that provides some basic fixtures.
+To enable the plugin, add the following line in your `conftest.py` module.
+
+```
+pytest_plugins = [
+    "nameko_injector.testing.pytest_fixtures",
+]
+```
+
+There are several fixtures that help during the testing. All of the fixtures
+have `function` pytest scope.
+
+- `service_class` fixture that **MUST** be redefined and return a service class under the test.
+
+- `web_service` fixture starts a real HTTP server to make real HTTP requests to our service. It can be used together with nameko's fixture `web_session` that injects HTTP client that knows a correct port. See `tests/test_injected.py` as an example.
+
+- `injector_in_test` fixture gives access to the `injector.Injector` instance that will resolve the dependencies in the service instance of `service_class`.
+  The fixture uses a child injector from the one that decorates the service that provides isolation between the test cases with the same class under the test.
+
+- `worker_ctx` fixture is used to get `injector_in_test` value but it's a mock
+  and might be redefined in your tests.
+
+How to redefine dependency?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Let's assume that service depends on an HTTP client for some 3rd-party service.
+In our test, we would like to use a mocked version of it. In that case, we need to
+redefine `injector_in_test` fixture.
+
+```python
+@pytest.fixture
+def injector_in_test(injector_in_test, mocked_http_client):
+    injector_in_test.binder.bind(ThirdPartyServiceHttpClient, to=mocked_http_client)
+    # injector_in_test.binder.install(MockedClientModule())
+    return injector_in_test
+```
+
+Sophisticated cases
+~~~~~~~~~~~~~~~~~~~
+In more *sophisticated* cases when we redefine how the server is started with
+`runner_factories` main task is to ensure that the container (service instance
+basically) has a valid injector. See
+`nameko_injector/testing/pytest_fixtures.py:web_service` code as an example.
+Main line there is `replace_dependencies(container, injector=injector_in_test)`.
 
 Development
 -----------
@@ -58,4 +104,3 @@ TODO
 ----
 
 - testing: Add the tests for RPC entry points
-- document testing with the library

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ In more *sophisticated* cases when we redefine how the server is started with
 ``runner_factories`` main task is to ensure that the container (service instance
 basically) has a valid injector. See
 ``nameko_injector/testing/pytest_fixtures.py:web_service`` code as an example.
-Main line there is ``replace_dependencies(container, injector=injector_in_test)``.
+Main line there is ``replace_dependencies(container, **container_overridden_dependencies)``.
 
 Development
 -----------

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ It works in many cases but there are limitations:
 1. All the dependencies are injected regardless of whether they are used in the entry-point. For instance, all the dependencies will be injected for ``/health`` HTTP entry point.
 2. Dependencies cannot depend on each other.
 3. The scope is an implementation detail. Frequency of the dependency creation depends on the ``DependencyProvider`` implementation.
-4. Subjectively, implementing a new `DependencyProvider` is not the easiest
+4. Subjectively, implementing a new ``DependencyProvider`` is not the easiest
    the task for the developers.
 
 Solution
@@ -50,51 +50,51 @@ An example:
       def view_config(self, request, config: ServiceConfig):
         return json.dumps(config)
 
-Testing with library
---------------------
+Testing with library (pytest)
+-----------------------------
 The library provides a module for pytest that provides some basic fixtures.
-To enable the plugin, add the following line in your `conftest.py` module.
+To enable the plugin, add the following line in your ``conftest.py`` module.
 
-```
-pytest_plugins = [
-    "nameko_injector.testing.pytest_fixtures",
-]
-```
+.. code:: python
+
+  pytest_plugins = [
+      "nameko_injector.testing.pytest_fixtures",
+  ]
 
 There are several fixtures that help during the testing. All of the fixtures
-have `function` pytest scope.
+have ``function`` pytest scope.
 
-- `service_class` fixture that **MUST** be redefined and return a service class under the test.
+- ``service_class`` fixture that **MUST** be redefined and return a service class under the test.
 
-- `web_service` fixture starts a real HTTP server to make real HTTP requests to our service. It can be used together with nameko's fixture `web_session` that injects HTTP client that knows a correct port. See `tests/test_injected.py` as an example.
+- ``web_service`` fixture starts a real HTTP server to make real HTTP requests to our service. It can be used together with nameko's fixture ``web_session`` that injects HTTP client that knows a correct port. See ``tests/test_injected.py`` as an example.
 
-- `injector_in_test` fixture gives access to the `injector.Injector` instance that will resolve the dependencies in the service instance of `service_class`.
+- ``injector_in_test`` fixture gives access to the ``injector.Injector`` instance that will resolve the dependencies in the service instance of ``service_class``.
   The fixture uses a child injector from the one that decorates the service that provides isolation between the test cases with the same class under the test.
 
-- `worker_ctx` fixture is used to get `injector_in_test` value but it's a mock
+- ``worker_ctx`` fixture is used to get ``injector_in_test`` value but it's a mock
   and might be redefined in your tests.
 
 How to redefine dependency?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Let's assume that service depends on an HTTP client for some 3rd-party service.
 In our test, we would like to use a mocked version of it. In that case, we need to
-redefine `injector_in_test` fixture.
+redefine ``injector_in_test`` fixture.
 
-```python
-@pytest.fixture
-def injector_in_test(injector_in_test, mocked_http_client):
-    injector_in_test.binder.bind(ThirdPartyServiceHttpClient, to=mocked_http_client)
-    # injector_in_test.binder.install(MockedClientModule())
-    return injector_in_test
-```
+.. code:: python
+
+  @pytest.fixture
+  def injector_in_test(injector_in_test, mocked_http_client):
+      injector_in_test.binder.bind(ThirdPartyServiceHttpClient, to=mocked_http_client)
+      # injector_in_test.binder.install(MockedClientModule())
+      return injector_in_test
 
 Sophisticated cases
 ~~~~~~~~~~~~~~~~~~~
 In more *sophisticated* cases when we redefine how the server is started with
-`runner_factories` main task is to ensure that the container (service instance
+``runner_factories`` main task is to ensure that the container (service instance
 basically) has a valid injector. See
-`nameko_injector/testing/pytest_fixtures.py:web_service` code as an example.
-Main line there is `replace_dependencies(container, injector=injector_in_test)`.
+``nameko_injector/testing/pytest_fixtures.py:web_service`` code as an example.
+Main line there is ``replace_dependencies(container, injector=injector_in_test)``.
 
 Development
 -----------

--- a/nameko_injector/testing/pytest_fixtures.py
+++ b/nameko_injector/testing/pytest_fixtures.py
@@ -1,19 +1,34 @@
+import uuid
+from unittest import mock
+
 import pytest
+from nameko.containers import WorkerContext
+from nameko.testing.services import replace_dependencies
+from nameko.testing.utils import get_container
 
-from ..core import NamekoInjector
-
-
-@pytest.fixture
-def injector_bindings():
-    """Mapping of the overriding bindings for service injector."""
-    return dict()
+from ..core import NamekoInjectorProvider
 
 
 @pytest.fixture
-def injector_in_test(service_class, injector_bindings):
-    return NamekoInjector(
-        bindings=dict(service_class.__injector_bindings__, **injector_bindings)
-    )
+def worker_ctx(service_class):
+    # Redefine this fixture in your tests
+    mocked_ctx = mock.Mock(spec=WorkerContext)
+    mocked_ctx.service_name = service_class.name
+    mocked_ctx.call_id = str(uuid.uuid4())
+    return mocked_ctx
+
+
+@pytest.fixture
+def injector_in_test(service_class, worker_ctx):
+    provider = service_class.injector
+    if not isinstance(provider, NamekoInjectorProvider):
+        raise ValueError(
+            "Injector-in-test cannot be created "
+            f"if the service class {service_class} in test "
+            "is not decorated with nameko-injector"
+        )
+    child_injector = provider.get_dependency(worker_ctx)
+    return child_injector
 
 
 @pytest.fixture
@@ -25,11 +40,26 @@ def service_class():
 
 
 @pytest.fixture
-def web_service(runner_factory, web_config, service_class, injector_in_test):
+def runner_and_container(runner_factory, service_class, web_config):
+    runner = runner_factory(web_config, service_class)
+    container = get_container(runner, service_class)
+    yield runner, container
+
+
+@pytest.fixture
+def container_overridden_dependencies(injector_in_test):
+    """Return provider name to a new value to be set on the container."""
+    # setting injector to injector_in_test is needed in 99% of the tests
+    return {"injector": injector_in_test}
+
+
+@pytest.fixture
+def web_service(
+    runner_and_container, web_config, service_class, container_overridden_dependencies
+):
     """Start service ready to serve HTTP requests."""
-    service_config = web_config
-    service_class = injector_in_test.decorate_service(service_class)
-    runner = runner_factory(service_config, service_class)
+    runner, container = runner_and_container
+    replace_dependencies(container, **container_overridden_dependencies)
     runner.start()
     yield
     runner.stop()

--- a/nameko_injector/testing/pytest_fixtures.py
+++ b/nameko_injector/testing/pytest_fixtures.py
@@ -40,13 +40,6 @@ def service_class():
 
 
 @pytest.fixture
-def runner_and_container(runner_factory, service_class, web_config):
-    runner = runner_factory(web_config, service_class)
-    container = get_container(runner, service_class)
-    yield runner, container
-
-
-@pytest.fixture
 def container_overridden_dependencies(injector_in_test):
     """Return provider name to a new value to be set on the container."""
     # setting injector to injector_in_test is needed in 99% of the tests
@@ -55,10 +48,11 @@ def container_overridden_dependencies(injector_in_test):
 
 @pytest.fixture
 def web_service(
-    runner_and_container, web_config, service_class, container_overridden_dependencies
+    service_class, container_overridden_dependencies, runner_factory, web_config
 ):
     """Start service ready to serve HTTP requests."""
-    runner, container = runner_and_container
+    runner = runner_factory(web_config, service_class)
+    container = get_container(runner, service_class)
     replace_dependencies(container, **container_overridden_dependencies)
     runner.start()
     yield

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 
 def main():
@@ -7,7 +8,7 @@ def main():
         name="nameko-injector",
         description="Injector support in nameko",
         long_description=Path("README.rst").read_text(),
-        version="0.1.2",
+        version="1.0.0",
         url="https://github.com/signalpillar/nameko-injector",
         license="MIT",
         platforms=["linux", "osx"],

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,10 @@ usedevelop = True
 
 [testenv:tests]
 deps =
-    pytest==3.5.1
-    mypy==0.761
-    radon==4.0.0
-    vulture==1.2
+    pytest==6.0.2
+    mypy==0.782
+    radon==4.3.2
+    vulture==2.1
 commands =
   mypy nameko_injector tests
   radon cc --total-average -n A nameko_injector


### PR DESCRIPTION
Problem
-------
It's not safe to bind WorkerContext to the injector used in the class of the
service as it will potentially conflict with different from other call.

Decisions
---------
- Do not use Mapping in the NamekoInjector init. It's not really useful. Take
  the same arguments as `injector.Injector`.
- Use child injectors on each service call to bind WorkerContext and that child
  injector is used to resolve the dependencies for the entry point method.
  Document better code.
- Improve pytest fixtures
- Rename scope from `request` to `request_scope`, it's less ambiguous.

Docs
----
Readme updated with some details about the available fixtures.