### PR TITLE
Add new type of scope to allow closing resources

### DIFF
--- a/nameko_injector/core.py
+++ b/nameko_injector/core.py
@@ -1,10 +1,15 @@
 import functools
+import logging
 import typing as t
+from weakref import WeakKeyDictionary
+import itertools
 
 import injector as inj
+from eventlet import corolocal
 from nameko.containers import ServiceContainer, WorkerContext
 from nameko.extensions import DependencyProvider
-from eventlet import corolocal
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class RequestScope(inj.Scope):
@@ -17,15 +22,34 @@ class RequestScope(inj.Scope):
         self._locals = corolocal.local()
 
     def get(self, interface: t.Any, provider: inj.Provider) -> inj.Provider:
+        key = repr(interface)
         try:
-            return getattr(self._locals, repr(interface))
+            return getattr(self._locals, key)
         except AttributeError:
             provider = inj.InstanceProvider(provider.get(self.injector))
-            setattr(self._locals, repr(interface), provider)
+            setattr(self._locals, key, provider)
             return provider
 
 
+class ResourceAwareRequestScope(RequestScope):
+    """Scope that is similar to RequestScope but is aware about resources.
+
+    Resource is a instance created in this scope that has 'close' method. This method
+    will be called in the end of the request.
+    """
+
+    def iter_closable(self):
+        for provider in vars(self._locals).values():
+            if isinstance(provider, inj.InstanceProvider):
+                inst = provider.get(self.injector)
+                if hasattr(inst, "close"):
+                    yield inst
+
+
 request_scope = inj.ScopeDecorator(RequestScope)
+# In this early stage of the project it's decided to have a separate scope instead of
+# supporting the case in the existing `RequestScope`.
+resource_request_scope = inj.ScopeDecorator(ResourceAwareRequestScope)
 
 
 class NamekoInjector(inj.Injector):
@@ -60,14 +84,45 @@ class NamekoInjectorProvider(DependencyProvider):
     def __init__(self, parent_injector: inj.Injector):
         # Bindings from the parent injector are shared between the calls.
         self.parent_injector = parent_injector
+        # Mapping of a worker context to child injector created for it.
+        # We need to be able to look up injector in different stages of the worker
+        # live-cycle.
+        self._injector_by_worker_ctx: WeakKeyDictionary = WeakKeyDictionary()
 
     def setup(self):
         # ServiceContainer is shared between the calls so it's in parent injector
-        self.parent_injector.binder.bind(ServiceContainer, to=self.container)
+        self.parent_injector.binder.bind(
+            ServiceContainer, to=self.container, scope=inj.singleton
+        )
 
     def get_dependency(self, worker_ctx):
         # Create child injector that will be used by decorated entrypoints.
-        # Having child injector is something that will help us in testing.
+        # Having child injector is something that will help us in testing and also
+        # isolate request-level dependencies bound per entry-point.
         child_injector = self.parent_injector.create_child_injector()
         child_injector.binder.bind(WorkerContext, worker_ctx, scope=request_scope)
+        self._injector_by_worker_ctx[worker_ctx] = child_injector
         return child_injector
+
+    def worker_teardown(self, worker_ctx):
+        """Called after a service worker has executed a task."""
+        # It's a good time to free resources in the request scope.
+        # Intentionally do not fallback to None if worker_ctx is not found. The service
+        # call won't fail but error should be reported in the logs.
+        child_injector = self._injector_by_worker_ctx.pop(worker_ctx)
+        # Normally, only when testing, child scope can have some resources. In the real
+        # app everything will be bound on the level of class injector (parent binder).
+        child_scope = child_injector.get(ResourceAwareRequestScope)
+        parent_scope = child_injector.parent.get(ResourceAwareRequestScope)
+
+        for closable in itertools.chain(
+            child_scope.iter_closable(), parent_scope.iter_closable()
+        ):
+            try:
+                closable.close()
+            except Exception:
+                _LOGGER.exception(
+                    "Failed to close request-scoped resource %r on worker teardown. "
+                    "Will attempt to close the rest of resources in the request scope.",
+                    closable.__class__,
+                )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def main():
         name="nameko-injector",
         description="Injector support in nameko",
         long_description=Path("README.rst").read_text(),
-        version="1.0.1",
+        version="1.1.0",
         url="https://github.com/signalpillar/nameko-injector",
         license="MIT",
         platforms=["linux", "osx"],

--- a/tests/dummy_service.py
+++ b/tests/dummy_service.py
@@ -74,3 +74,15 @@ class Service:
         return json.dumps(
             dict(service_name=context.service_name, call_id=context.call_id, id=id_)
         )
+
+    @http("GET", "/injector/access")
+    def check_injector_access(
+        self, request, injector: inj.Injector, binder: inj.Binder
+    ):
+        # Injector can be accessed both from the service state and as a param.
+        injector_from_nameko_injector_provider = self.injector  # type: ignore
+        assert injector_from_nameko_injector_provider is injector
+        # Same applies to binder.
+        assert injector_from_nameko_injector_provider.binder is binder
+        # This functionality is provided by the 'injector' library.
+        return "ok"

--- a/tests/test_injected.py
+++ b/tests/test_injected.py
@@ -68,3 +68,9 @@ class TestErrorRaisedDuringInjection:
         response = web_session.get("/config")
         assert 500 == response.status_code
         assert b"Error: ValueError: Failed to create config\n" == response.content
+
+
+def test_injector_access(web_session):
+    response = web_session.get("/injector/access")
+    assert 200 == response.status_code
+    assert b"ok" == response.content

--- a/tests/test_teardown_in_scopes.py
+++ b/tests/test_teardown_in_scopes.py
@@ -1,0 +1,176 @@
+"""Test resources can be closed in the end of the scope life-cycle."""
+import json
+from unittest import mock
+
+import injector as inj
+import pytest
+from nameko.web.handlers import http
+from nameko_injector.core import NamekoInjector, resource_request_scope
+
+
+# Main test of the module. It's goal is to ensure that resource with
+# 'resource_request_scope' scope is injected and in the end of request it's freed.
+# Checking this fact is quite a challenge as with the setup here we cannot access
+# - provider (copy of NamekoInjectorProvider is created by nameko), to read internal
+#   state
+# - injector_in_test as it's created for the request by provider which internal state is
+#   not accessible. Fixture doesn't work as we disabled mocking of the provider. With
+#   the mocking, life-cycle methods like 'worker_setup' or 'worker_teardown' are not
+#   called.
+# In the test a global state (DB_MODULE) will be used to access injected. Injected
+# resources have 'spy' field (mock instance) that records calls to 'close' method.
+def test_session_closed_after_request(web_service, web_session):
+    # When
+    response = web_session.get("/db/session")
+    # Then
+    assert 200 == response.status_code, str(response.content)
+    session_details = response.json()
+    # session that is expected to be injected in the HTTP handler
+    session = DB_MODULE.fake_db_session
+    assert session and session.engine is DB_MODULE.fake_db_engine
+    # Check 'close' method is called once.
+    session.spy.close.assert_called_once()
+
+    # Ensure that session is exactly what we need and was injected in the method.
+    assert id(session) == session_details.get("session_id")
+    assert id(DB_MODULE.fake_db_engine) == session_details.get("engine_id")
+
+
+def test_session_closed_even_if_another_resource_failed_closing(
+    web_service, web_session
+):
+    # When
+    response = web_session.get("/db/session/failing")
+    # Then
+    assert 200 == response.status_code, str(response.content)
+    session_details = response.json()
+
+    session = DB_MODULE.fake_db_session
+    failing_session = DB_MODULE.failing_db_session
+    assert session and failing_session
+
+    assert id(session) == session_details.get("session_id")
+    assert (
+        id(DB_MODULE.fake_db_engine)
+        == session_details.get("engine_id")
+        == id(session.engine)
+        == id(failing_session.engine)
+    )
+
+    session.spy.close.assert_called_once()
+    assert not failing_session.spy.close.called
+
+
+class Spy:
+    def __init__(self, injected_with: inj.Injector):
+        self.spy = mock.Mock()
+        self.injected_with = injected_with
+
+    def close(self):
+        self.spy.close()
+
+
+# FakeDBEngine and FakeDBSession are resources that will be used in the test in
+# different scopes. They play role of those resources that SHOULD be closed in the end
+# of the scope life-cycle.
+class FakeDBEngine(Spy):
+    """Engine is a singleton created once based on the configuration"""
+
+
+class FakeDBSession(Spy):
+    """Session is created per request and must be closed after usage."""
+
+    def __init__(self, engine: FakeDBEngine, injected_with: inj.Injector) -> None:
+        super().__init__(injected_with=injected_with)
+        self.engine = engine
+
+
+class FailingOnCloseDBSession(FakeDBSession):
+    def close(self):
+        raise RuntimeError("Something went wrong")
+
+
+class DBModule(inj.Module):
+    def __init__(self):
+        # The fields are only for testing purpose as it's really hard to access injected
+        # objects from the test itself using provider, injector_in_test or other way or
+        # mocking.
+        # It makes impossible to run the tests in parallel.
+        self.fake_db_engine = None
+        self.fake_db_session = None
+        self.failing_db_session = None
+
+    def configure(self, binder: inj.Binder) -> None:
+        binder.bind(FakeDBEngine, to=self._provide_db_engine, scope=inj.singleton)
+        binder.bind(
+            FakeDBSession, to=self._provide_db_session, scope=resource_request_scope
+        )
+        binder.bind(
+            FailingOnCloseDBSession,
+            to=self._provide_failing_db_session,
+            scope=resource_request_scope,
+        )
+
+    @inj.provider
+    def _provide_db_engine(self, injector: inj.Injector) -> FakeDBEngine:
+        self.fake_db_engine = FakeDBEngine(injected_with=injector)
+        return self.fake_db_engine
+
+    @inj.provider
+    def _provide_failing_db_session(
+        self, engine: FakeDBEngine, injector: inj.Injector
+    ) -> FailingOnCloseDBSession:
+        self.failing_db_session = FailingOnCloseDBSession(
+            engine=engine, injected_with=injector
+        )
+        return self.failing_db_session
+
+    @inj.provider
+    def _provide_db_session(
+        self, engine: FakeDBEngine, injector: inj.Injector
+    ) -> FakeDBSession:
+        self.fake_db_session = FakeDBSession(engine=engine, injected_with=injector)
+        return self.fake_db_session
+
+
+DB_MODULE = DBModule()
+
+
+INJECTOR = NamekoInjector(DB_MODULE)
+
+
+@INJECTOR.decorate_service
+class Service:
+    name = "service"
+
+    @http("GET", "/db/session/failing")
+    def view_db_failing_session_id(
+        self,
+        request,
+        session: FakeDBSession,
+        failing_db_session: FailingOnCloseDBSession,
+        injector: inj.Injector,
+    ):
+        return json.dumps(
+            dict(
+                session_id=id(session),
+                engine_id=id(session.engine),
+                failing_db_session_id=id(failing_db_session),
+            )
+        )
+
+    @http("GET", "/db/session")
+    def view_db_session_id(self, request, session: FakeDBSession):
+        return json.dumps(dict(session_id=id(session), engine_id=id(session.engine)))
+
+
+@pytest.fixture
+def service_class():
+    return Service
+
+
+@pytest.fixture
+def container_overridden_dependencies():
+    # Do not override NamekoInjectorProvider as it prevents calling of worker_* methods
+    # on the provider.
+    return {}

--- a/tox.ini
+++ b/tox.ini
@@ -24,3 +24,12 @@ deps =
 commands =
       pre-commit install -f --install-hooks
       pre-commit {posargs:run --all-files}
+
+
+[flake8]
+# Because it's default for black formatter used in the project.
+max-line-length = 88
+
+[pytest]
+log_format = %(asctime)s %(levelname)s %(message)s
+log_cli = true


### PR DESCRIPTION
Problem
-------
Some resources in request scope need to be closed (freed). It's not currently
supported.

Solution
--------
Create a new type of scope that's aware about resources with 'close' method.
Name of this special method is hardcoded. Probably we could use protocol in this
case - `Closable`.

It's a separate type of scope to make the fact that resource will be closed more
explicit. When one of the resources cannot be closed, the failure will be logged
but teardown call is not failed so the rest can be closed.

**Second change** is that ServiceContainer is now in singleton scope as it
should be.

Testing
-------
Added test cases.