### PR TITLE
[bugfix] Prevent memory-leak in request scopes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def main():
         name="nameko-injector",
         description="Injector support in nameko",
         long_description=Path("README.rst").read_text(),
-        version="1.1.1",
+        version="1.1.2",
         url="https://github.com/signalpillar/nameko-injector",
         license="MIT",
         platforms=["linux", "osx"],


### PR DESCRIPTION
Problem
-------
`corolocal.local` keeps references to all the coroutines (green threads) and the
resources allocated in the scope for that thread. It prevents GC collecting used
injectables.

Solution
--------
Manually clean scope storage in the end of each
request (`NamekoInjectorProvider.worker_teardown`)